### PR TITLE
deleted deprecatad parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is a dockerized version of the [PiShrink bash script](https://githu
     docker run --privileged=true --rm \
         --volume $(pwd):/workdir \
         mgomesborges/pishrink \
-        pishrink -pZv IMAGE.img NEW-IMAGE.img
+        pishrink -Zv IMAGE.img NEW-IMAGE.img
     ```
 
 ## PiShrink options


### PR DESCRIPTION
Deleted -p parameter from readme. The docker container was failing because of that.